### PR TITLE
feat(seo): JSON-LD 구조화 데이터 보강

### DIFF
--- a/.claude/skills/verify-json-ld/SKILL.md
+++ b/.claude/skills/verify-json-ld/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: verify-json-ld
+description: >-
+  Build this Hugo site and validate the JSON-LD structured data it emits — valid JSON, resolvable @id links, no JSON-LD on noindex pages, and the expected schema.org entities per page type (home/post/posts-section, both languages). Use this whenever JSON-LD, structured data, schema.org, rich results, or the SEO `<head>` are touched — e.g. after editing `layouts/_partials/head/seo.html` or the `[person]` block in `config/_default/params.toml`, before pushing SEO changes, or when asked to "check / verify / validate the structured data (or JSON-LD)". Prefer this over hand-rolling a one-off build-and-grep.
+---
+
+# Verify JSON-LD
+
+This site's JSON-LD is generated in `layouts/_partials/head/seo.html` (a DoIt theme override). Because it is template-driven, a small template change can silently break the markup on a whole class of pages. This skill rebuilds the site and checks the emitted markup so regressions surface immediately.
+
+## How to run
+
+From the repo root:
+
+```bash
+python3 .claude/skills/verify-json-ld/scripts/validate.py
+```
+
+It builds with `hugo --gc --minify --cleanDestinationDir` (the clean flag drops orphaned HTML from deleted/renamed content, which would otherwise read as false positives), then scans every page in `public/`. Exit code is non-zero on any failure, so it also works as a pre-push or CI gate.
+
+Pass `--no-build` to validate an existing `public/` without rebuilding (faster when you just built).
+
+## What it checks
+
+**Structural invariants** (hold regardless of design):
+
+- Every `application/ld+json` block parses as valid JSON.
+- Every `@id` _reference_ resolves to a node defined somewhere on the site. Resolution is site-wide on purpose: Google merges entities by `@id` across pages, so a paginated page referencing `#person` without redefining it is fine, but a typo or stale URL (e.g. an old domain) is caught.
+- noindex pages emit **zero** JSON-LD — putting structured data on pages that won't be indexed has no SEO value.
+
+**Per-page-type expected entities** (the current design contract):
+
+| Page kind     | Required `@type`s                         |
+| ------------- | ----------------------------------------- |
+| home          | `WebSite`, `ProfilePage`, `Person`        |
+| posts section | `Blog`, `Person`                          |
+| post          | `BlogPosting`, `BreadcrumbList`, `Person` |
+
+Both English and Korean pages are covered automatically — the script walks every built page and classifies it by path (`noindex` wins over everything).
+
+## When checks fail
+
+Read each line: it names the page and the problem. Common causes:
+
+- _missing expected @type_ — a template branch didn't fire for that page kind; check the relevant `if`/`else if` in `seo.html`.
+- _dangling @id reference_ — a node references an entity that is never defined (often a stale/old-domain URL, or a `@type` dropped from a definition).
+- _noindex page has N blocks_ — the page branch isn't gated on `not .Params.noindex`.
+
+## When the design intentionally changes
+
+If you deliberately add/remove an entity (e.g. start emitting `Article` on a new section), update the `EXPECTATIONS` map at the top of `scripts/validate.py` and the page-kind classification in `classify()` so the contract matches reality. The script is the executable spec for what this site's JSON-LD should contain.

--- a/.claude/skills/verify-json-ld/scripts/validate.py
+++ b/.claude/skills/verify-json-ld/scripts/validate.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+"""Validate the JSON-LD that Hugo emits for this site.
+
+Builds the site (unless --no-build), then parses every `application/ld+json`
+block out of `public/` and checks three things:
+
+1. Structural invariants that hold regardless of design:
+   - every block is valid JSON
+   - every `@id` *reference* resolves to a node defined somewhere on the site
+     (Google merges entities by `@id` across pages, so a paginated page may
+     reference `#person` without redefining it — that is fine)
+   - noindex pages emit no JSON-LD at all (it has no SEO value there)
+
+2. Per-page-type expected entities (the current site design — edit
+   EXPECTATIONS below if the design intentionally changes). Covers both
+   languages automatically by walking every built page.
+
+Exit code is non-zero if any check fails, so it doubles as a CI/pre-push gate.
+"""
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+# Page kind -> @type entities that must be present. This is the regression
+# contract for the current design; update it deliberately when the design does.
+EXPECTATIONS = {
+    "home": ["WebSite", "ProfilePage", "Person"],
+    "posts_section": ["Blog", "Person"],
+    "post": ["BlogPosting", "BreadcrumbList", "Person"],
+}
+
+LD_BLOCK = re.compile(
+    r'<script type=["\']?application/ld\+json["\']?>(.*?)</script>', re.S
+)
+NOINDEX = re.compile(r'name=["\']robots["\'][^>]*content=["\'][^"\']*noindex', re.I)
+
+
+def classify(relpath: str, html: str) -> str:
+    """Map a built page to a kind. noindex wins over everything else."""
+    if NOINDEX.search(html):
+        return "noindex"
+    if relpath in ("index.html", "ko/index.html"):
+        return "home"
+    if relpath in ("posts/index.html", "ko/posts/index.html"):
+        return "posts_section"
+    if re.fullmatch(r"(ko/)?posts/[^/]+/index\.html", relpath):
+        return "post"
+    return "other"  # pagination, taxonomies that are indexed, etc.
+
+
+def walk(node, defined: set, refs: list):
+    """Collect defined @ids (nodes with @type) and pure @id references."""
+    if isinstance(node, dict):
+        if "@id" in node and isinstance(node["@id"], str):
+            if "@type" in node:
+                defined.add(node["@id"])
+            else:
+                refs.append(node["@id"])
+        for v in node.values():
+            walk(v, defined, refs)
+    elif isinstance(node, list):
+        for v in node:
+            walk(v, defined, refs)
+
+
+def types_in(objs) -> list:
+    """Flatten all @type values across blocks (handles @graph)."""
+    found = []
+
+    def rec(node):
+        if isinstance(node, dict):
+            t = node.get("@type")
+            if isinstance(t, str):
+                found.append(t)
+            for v in node.values():
+                rec(v)
+        elif isinstance(node, list):
+            for v in node:
+                rec(v)
+
+    for o in objs:
+        rec(o)
+    return found
+
+
+def check_page(relpath: str, html: str, failures: list, defined: set, refs: list):
+    """Validate one page; accumulate site-wide @id defs/refs for a later pass."""
+    kind = classify(relpath, html)
+    raw_blocks = LD_BLOCK.findall(html)
+
+    # noindex: must be empty.
+    if kind == "noindex":
+        if raw_blocks:
+            failures.append(f"{relpath}: noindex page has {len(raw_blocks)} JSON-LD block(s), expected 0")
+        return
+
+    # Parse every block; collect objects.
+    objs = []
+    for i, raw in enumerate(raw_blocks):
+        try:
+            objs.append(json.loads(raw))
+        except json.JSONDecodeError as e:
+            failures.append(f"{relpath}: block {i} is invalid JSON ({e})")
+
+    # Accumulate @id definitions and references for the site-wide pass.
+    for o in objs:
+        page_refs = []
+        walk(o, defined, page_refs)
+        refs.extend((relpath, r) for r in page_refs)
+
+    # Per-page-type expected entities.
+    if kind in EXPECTATIONS:
+        present = set(types_in(objs))
+        for t in EXPECTATIONS[kind]:
+            if t not in present:
+                failures.append(f"{relpath}: missing expected @type {t!r} for {kind} page (present: {sorted(present)})")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--no-build", action="store_true", help="validate existing public/ without rebuilding")
+    ap.add_argument("--public", default="public", help="built site directory (default: public)")
+    args = ap.parse_args()
+
+    if not args.no_build:
+        # --cleanDestinationDir drops orphaned HTML from deleted/renamed content,
+        # which would otherwise show up as stale false positives.
+        print("Building site (hugo --gc --minify --cleanDestinationDir)...")
+        r = subprocess.run(["hugo", "--gc", "--minify", "--cleanDestinationDir"], capture_output=True, text=True)
+        if r.returncode != 0:
+            print(r.stdout)
+            print(r.stderr, file=sys.stderr)
+            print("\n❌ Hugo build failed.", file=sys.stderr)
+            return 1
+
+    public = Path(args.public)
+    if not public.is_dir():
+        print(f"❌ {public}/ not found. Build first or pass --public.", file=sys.stderr)
+        return 1
+
+    failures, pages, with_ld = [], 0, 0
+    defined, refs = set(), []  # site-wide @id definitions and (page, ref) pairs
+    for f in sorted(public.rglob("index.html")):
+        rel = f.relative_to(public).as_posix()
+        html = f.read_text(encoding="utf-8")
+        pages += 1
+        if LD_BLOCK.search(html):
+            with_ld += 1
+        check_page(rel, html, failures, defined, refs)
+
+    # Site-wide @id resolution.
+    for relpath, r in refs:
+        if r not in defined:
+            failures.append(f"{relpath}: dangling @id reference {r!r} (not defined anywhere on site)")
+
+    print(f"\nScanned {pages} pages ({with_ld} with JSON-LD).")
+    if failures:
+        print(f"\n❌ {len(failures)} problem(s):\n")
+        for msg in failures:
+            print(f"  - {msg}")
+        return 1
+    print("\n✅ All JSON-LD checks passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/DavidAnson/markdownlint-cli2
-    rev: v0.17.2
+    rev: v0.22.1
     hooks:
       - id: markdownlint-cli2
         args: ["--fix"]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,6 +62,14 @@ See `.github/instructions/seo-master.instructions.md` for detailed SEO rules. Ke
 - Meta descriptions: 1-2 sentences, role-centric, not literary
 - Entity name format when combined: "Jeongseop Lim (임정섭)"
 
+### JSON-LD / Structured Data
+
+- Implemented in `layouts/_partials/head/seo.html` (overrides the DoIt theme); Person entity data lives in `config/_default/params.toml` `[person]`.
+- Entities: home → `WebSite` + `ProfilePage` + `Person`; posts → `BlogPosting` + `BreadcrumbList` + `Person`; `/posts/` → `Blog`. Cross-linked by `@id` (`#person`, `#profilepage`, `#blog`).
+- Do NOT emit JSON-LD on noindex pages (categories/tags/series/authors are intentionally noindex; only `/posts/` and posts are indexed) — it has no SEO value.
+- Keep structured data a clean, accurate core that mirrors visible content; don't maximize subjective fields (no ranking benefit, risks spammy-markup violations). E.g. model the grad lab as `memberOf`, not `worksFor`.
+- Verify by building (`hugo --gc --minify`) and extracting `application/ld+json` from `public/` (output HTML is minified).
+
 ## CI
 
 GitHub Actions runs on every push:

--- a/config/_default/params.toml
+++ b/config/_default/params.toml
@@ -41,11 +41,20 @@ keywords = []  # NOTE: HTML 렌더링 안되고 있고, 현대 검색엔진에�
 # Person entity for structured data (JSON-LD)
 [person]
   name = "Jeongseop Lim"
+  givenName = "Jeongseop"
+  familyName = "Lim"
   alternateName = "임정섭"
   url = "https://jseoplim.com"
   email = "jeongseop_lim@korea.ac.kr"
   image = "https://www.gravatar.com/avatar/bf58c456601a5a79921f60c3b62a41c2?s=400&d=mp"
   jobTitle = "Graduate Student"
+  description = "Master's student in Computer Science and Engineering at Korea University's Software Analysis Lab, researching practical program analysis for real-world software."
+  knowsAbout = [
+    "Programming languages",
+    "Static program analysis",
+    "Python",
+    "Automated software testing",
+  ]
   sameAs = [
     "https://github.com/jseop-lim",
     "https://www.linkedin.com/in/jseop-lim",
@@ -56,10 +65,18 @@ keywords = []  # NOTE: HTML 렌더링 안되고 있고, 현대 검색엔진에�
     type = "CollegeOrUniversity"
     name = "Korea University"
     url = "https://korea.ac.kr"
-  [person.alumniOf]
+  [person.memberOf]
+    type = "ResearchOrganization"
+    name = "Software Analysis Lab"
+    url = "https://prl.korea.ac.kr"
+  [[person.alumniOf]]
     type = "CollegeOrUniversity"
     name = "Korea University"
     url = "https://korea.ac.kr"
+  [[person.alumniOf]]
+    type = "HighSchool"
+    name = "Daegu Science High School"
+    url = "https://dshs.dge.hs.kr"
 
 [image]
   # cache remote images for better optimisations

--- a/layouts/_partials/head/seo.html
+++ b/layouts/_partials/head/seo.html
@@ -253,7 +253,7 @@
     {{- $paginatorPager := .Scratch.Get "paginatorPager" -}}
     {{- /* If the post is disabled then it is the homepage */ -}}
     {{- $postDisable := not $.Site.Params.home.posts.enable -}}
-    {{- $isPaginationAndHomepage := and $paginatorPager (eq $paginatorPager.PageNumber 1) (eq $paginatorPager.URL "/") -}}
+    {{- $isPaginationAndHomepage := and $paginatorPager (eq $paginatorPager.PageNumber 1) (eq $paginatorPager.URL .RelPermalink) -}}
     {{- $showWebSite := or $isPaginationAndHomepage $postDisable -}}
     {{- if or $showBlogPosting $showWebSite -}}
         <script type="application/ld+json">

--- a/layouts/_partials/head/seo.html
+++ b/layouts/_partials/head/seo.html
@@ -37,6 +37,12 @@
         "@type": "Person",
         "@id": "{{ .url }}/#person",
         "name": {{ .name | safeHTML }},
+        {{- with .givenName -}}
+            "givenName": {{ . | safeHTML }},
+        {{- end -}}
+        {{- with .familyName -}}
+            "familyName": {{ . | safeHTML }},
+        {{- end -}}
         {{- with .alternateName -}}
             "alternateName": {{ . | safeHTML }},
         {{- end -}}
@@ -50,6 +56,17 @@
         {{- with .jobTitle -}}
             "jobTitle": "{{ . }}",
         {{- end -}}
+        {{- with .description -}}
+            "description": {{ . | safeHTML }},
+        {{- end -}}
+        {{- with .knowsAbout -}}
+            "knowsAbout": [
+                {{- range $index, $value := . -}}
+                    {{- if gt $index 0 }},{{ end -}}
+                    "{{ $value }}"
+                {{- end -}}
+            ],
+        {{- end -}}
         {{- with .affiliation -}}
             "affiliation": {
                 "@type": "{{ .type }}",
@@ -57,12 +74,24 @@
                 "url": "{{ .url }}"
             },
         {{- end -}}
-        {{- with .alumniOf -}}
-            "alumniOf": {
+        {{- with .memberOf -}}
+            "memberOf": {
                 "@type": "{{ .type }}",
                 "name": "{{ .name }}",
                 "url": "{{ .url }}"
             },
+        {{- end -}}
+        {{- with .alumniOf -}}
+            "alumniOf": [
+                {{- range $index, $value := . -}}
+                    {{- if gt $index 0 }},{{ end -}}
+                    {
+                        "@type": "{{ $value.type }}",
+                        "name": "{{ $value.name }}",
+                        "url": "{{ $value.url }}"
+                    }
+                {{- end -}}
+            ],
         {{- end -}}
         {{- with .sameAs -}}
             "sameAs": [

--- a/layouts/_partials/head/seo.html
+++ b/layouts/_partials/head/seo.html
@@ -352,8 +352,8 @@
         </script>
     {{- end -}}
 
-{{- /* Page SEO */ -}}
-{{- else if .IsPage -}}
+{{- /* Page SEO — indexed pages only */ -}}
+{{- else if and .IsPage (not .Params.noindex) -}}
     <script type="application/ld+json">
         {{- template "blogPosting" . -}}
     </script>

--- a/layouts/_partials/head/seo.html
+++ b/layouts/_partials/head/seo.html
@@ -357,7 +357,29 @@
     <script type="application/ld+json">
         {{- template "blogPosting" . -}}
     </script>
-    {{- /* Standalone Person entity on every page */ -}}
+    {{- /* BreadcrumbList */ -}}
+    {{- $ancestors := .Ancestors.Reverse -}}
+    <script type="application/ld+json">
+        {"@context": "https://schema.org",
+        "@type": "BreadcrumbList",
+        "itemListElement": [
+        {{- range $index, $node := $ancestors -}}
+            {{- if gt $index 0 -}},{{- end -}}
+            {
+                "@type": "ListItem",
+                "position": {{ add $index 1 }},
+                "name": {{ $node.Title | safeHTML }},
+                "item": {{ $node.Permalink }}
+            }
+        {{- end -}}
+        ,{
+            "@type": "ListItem",
+            "position": {{ add (len $ancestors) 1 }},
+            "name": {{ .Title | safeHTML }}
+        }
+        ]}
+    </script>
+    {{- /* Standalone Person entity */ -}}
     {{- with .Site.Params.person -}}
     <script type="application/ld+json">
     {{- template "personEntity" (dict "Site" $.Site "Standalone" true) -}}

--- a/layouts/_partials/head/seo.html
+++ b/layouts/_partials/head/seo.html
@@ -162,7 +162,6 @@
                 {{- end -}}
             ],
         {{- end -}}
-        "genre": "{{ .Type }}",
         {{- if .Params.keywords -}}
             "keywords": {{- apply .Params.keywords "safeHTML" "." -}},
         {{- else if .Params.tags -}}

--- a/layouts/_partials/head/seo.html
+++ b/layouts/_partials/head/seo.html
@@ -103,7 +103,7 @@
         {{- end -}}
         "mainEntityOfPage": {
             "@type": "WebPage",
-            "@id": "{{ $.Site.Params.person.url }}/"
+            "@id": "{{ $.Site.Params.person.url }}/#profilepage"
         }
     }
 {{- end -}}
@@ -324,6 +324,18 @@
                     },
                 {{- end -}}
                 "name": {{ .Site.Title | safeHTML }}
+            },
+            {{- /* ProfilePage entity in @graph */ -}}
+            {
+                "@type": "ProfilePage",
+                "@id": "{{ .Permalink }}#profilepage",
+                "url": {{ .Permalink }},
+                {{- if not .Lastmod.IsZero -}}
+                    "dateModified": {{ .Lastmod.Format "2006-01-02T15:04:05-07:00" | safeHTML }},
+                {{- end -}}
+                "mainEntity": {
+                    "@id": "{{ .Site.Params.person.url }}/#person"
+                }
             },
             {{- /* Person entity in @graph */ -}}
             {{- template "personEntity" (dict "Site" .Site "Standalone" false) -}}

--- a/layouts/_partials/head/seo.html
+++ b/layouts/_partials/head/seo.html
@@ -46,7 +46,7 @@
         {{- with .alternateName -}}
             "alternateName": {{ . | safeHTML }},
         {{- end -}}
-        "url": "{{ .url }}",
+        "url": "{{ .url }}/",
         {{- with .email -}}
             "email": "{{ . }}",
         {{- end -}}

--- a/layouts/_partials/head/seo.html
+++ b/layouts/_partials/head/seo.html
@@ -363,4 +363,28 @@
     {{- template "personEntity" (dict "Site" $.Site "Standalone" true) -}}
     </script>
     {{- end -}}
+
+{{- /* Section SEO — indexed sections only */ -}}
+{{- else if and .IsSection (eq .Section "posts") -}}
+    <script type="application/ld+json">
+        {"@context": "https://schema.org",
+        "@graph": [
+            {
+                "@type": "Blog",
+                "@id": "{{ .Permalink }}#blog",
+                "url": {{ .Permalink }},
+                "name": {{ T "allSome" (dict "Some" (T .Section)) | safeHTML }},
+                {{- with .Site.LanguageCode -}}
+                    "inLanguage": "{{ . }}",
+                {{- end -}}
+                "author": {
+                    "@id": "{{ .Site.Params.person.url }}/#person"
+                },
+                "publisher": {
+                    "@id": "{{ .Site.Params.person.url }}/#person"
+                }
+            },
+            {{- template "personEntity" (dict "Site" .Site "Standalone" false) -}}
+        ]}
+    </script>
 {{- end -}}


### PR DESCRIPTION
## 개요

기존 JSON-LD 구현(테마 오버라이드 `seo.html`)을 보강하고, 검증을 자동화합니다. "최대한 많이"가 아니라 본문과 일치하는 깨끗한 코어를 지향했고, noindex 페이지에는 구조화 데이터를 넣지 않습니다.

## 변경 사항

- **Person 강화**: `givenName`/`familyName`/`description`/`knowsAbout`/`memberOf` 추가, `alumniOf` 배열화. 대학원 연구실은 고용이 아니라 구성원이므로 `worksFor`가 아닌 `memberOf`로 모델링.
- **홈 ProfilePage**: `mainEntity ↔ mainEntityOfPage`로 Person과 양방향 연결.
- **`/posts/` Blog**: 색인되는 글 섹션에만 추가(저자·발행자는 Person 참조).
- **BreadcrumbList**: 색인되는 글 페이지에 추가.
- **noindex 페이지 제외**: noindex 페이지에는 JSON-LD를 출력하지 않음.
- **버그 수정**: 한국어 홈(`/ko/`)에 WebSite·Person이 누락되던 게이팅 버그 수정.
- **정리**: 의미 없는 `genre` 제거, `Person.url`을 정식 홈 주소(끝 슬래시)로 정정.

## 부수 산출물

- 구조화 데이터 규약·정책을 CLAUDE.md에 문서화.
- 빌드 후 JSON-LD를 검증하는 `verify-json-ld` 스킬 추가(유효 JSON, `@id` 연결, noindex 0개, 페이지별 기대 엔티티).

## 후속

언어 신호 불일치(`<html lang>` / `og:locale` / `inLanguage`)는 i18n 전략 차원의 문제라 별도 이슈로 분리: jseop-lim/jseoplim-profile-hugo#91

## 검증

`verify-json-ld` 스킬로 전 페이지 통과 확인(en·ko).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
