### PR TITLE
docs: markdownlint CI 범위·버전 정합 주의 추가

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,7 +75,9 @@ See `.github/instructions/seo-master.instructions.md` for detailed SEO rules. Ke
 GitHub Actions runs on every push:
 
 1. `compare-multi-lang` — verifies English/Korean content files match
-2. `markdown-lint` — validates all Markdown files
+2. `markdown-lint` — runs markdownlint-cli2 over all `**/*.md`, including `.claude/`
+
+Keep the pre-commit `markdownlint-cli2` rev's markdownlint version in sync with the CI action's, or markdown can pass the local hook but fail CI.
 
 ## Workflow
 


### PR DESCRIPTION
CLAUDE.md CI 섹션에 markdownlint 관련 주의를 추가합니다.

- markdown-lint는 `.claude/` 포함 `**/*.md` 전체를 검사함을 명시
- pre-commit의 markdownlint-cli2 버전을 CI와 맞춰야 로컬 통과/CI 실패를 피할 수 있다는 caveat

🤖 Generated with [Claude Code](https://claude.com/claude-code)